### PR TITLE
Clamp entity position to parent boundaries

### DIFF
--- a/GeonBit.UI/GeonBit.UI/Entities/Entity.cs
+++ b/GeonBit.UI/GeonBit.UI/Entities/Entity.cs
@@ -1157,7 +1157,7 @@ namespace GeonBit.UI.Entities
                 if (ret.Bottom > parent_bottom)
                 {
                     ret.Y -= ret.Bottom - parent_bottom;
-                    if (_draggable) _dragOffset.Y -= ret.Bottom - parent_bottom; }
+                    if (_draggable) { _dragOffset.Y -= ret.Bottom - parent_bottom; }
                 }
             }
 


### PR DESCRIPTION
I thought it would be handy to have a flag similar to `Entity.LimitDraggingToParentBoundaries` that applied to all positioning, not just when the entity is being dragged.

I just pulled the checks out of the logic for draggables and had them checked for any entity with the new `Entity.LimitPositionToParentBoundaries` flag set. I've left `Entity.LimitDraggingToParentBoundaries` to not break the API, and it also technically means that you could manually position an entity outside its parent's bounds, but then clamp the position if the entity is dragged (which might be useful for somebody?).