### PR TITLE
Fix for dragging issues

### DIFF
--- a/GeonBit.UI/GeonBit.UI/Entities/Entity.cs
+++ b/GeonBit.UI/GeonBit.UI/Entities/Entity.cs
@@ -1373,7 +1373,7 @@ namespace GeonBit.UI.Entities
         {
             // get rectangle for the test
             Rectangle rect = UseActualSizeForCollision ? GetActualDestRect() : _destRect;
-            
+
             // now test detection
             return (point.X >= rect.Left && point.X <= rect.Right &&
                     point.Y >= rect.Top && point.Y <= rect.Bottom);
@@ -1432,7 +1432,7 @@ namespace GeonBit.UI.Entities
             // if disabled, invisible, or locked - skip
             if (_isCurrentlyDisabled || IsLocked() || !IsVisible())
             {
-                // if this very entity is locked (eg not locked due to parent being locked), 
+                // if this very entity is locked (eg not locked due to parent being locked),
                 // iterate children and invoke those with DoEventsIfDirectParentIsLocked setting
                 if (Locked)
                 {
@@ -1487,12 +1487,6 @@ namespace GeonBit.UI.Entities
                             targetEntity = this;
                         }
 
-                        // set self as the dragging target, but only if draggable or interactive
-                        if (_draggable || IsNaturallyInteractable())
-                        {
-                            dragTargetEntity = this;
-                        }
-
                         // mouse is over entity
                         _isMouseOver = true;
 
@@ -1520,6 +1514,11 @@ namespace GeonBit.UI.Entities
             for (int i = childrenSorted.Count - 1; i >= 0; i--)
             {
                 childrenSorted[i].Update(input, ref targetEntity, ref dragTargetEntity, ref wasEventHandled);
+            }
+
+            // check dragging after children so that the most nested entity gets priority
+            if ((_draggable || IsNaturallyInteractable()) && dragTargetEntity == null && _isMouseOver && input.MouseButtonPressed(MouseButton.Left)) {
+                dragTargetEntity = this;
             }
 
             // STEP 3: CALL EVENTS
@@ -1589,8 +1588,8 @@ namespace GeonBit.UI.Entities
 
             // STEP 4: HANDLE DRAGGING FOR DRAGABLES
 
-            // if draggable, and after calling all the children target is still self, it means we are being dragged!
-            if (_draggable && (dragTargetEntity == this) && input.MouseButtonDown(MouseButton.Left) && IsFocused)
+            // if draggable, and after calling all the children target is self, it means we are being dragged!
+            if (_draggable && (dragTargetEntity == this) && IsFocused)
             {
                 // check if we need to start dragging the entity that was not dragged before
                 if (!_isBeingDragged && input.MousePositionDiff.Length() != 0)

--- a/GeonBit.UI/GeonBit.UI/UserInterface.cs
+++ b/GeonBit.UI/GeonBit.UI/UserInterface.cs
@@ -63,6 +63,9 @@ namespace GeonBit.UI
         // root panel that covers the entire screen and everything is added to it
         static Panel _root;
 
+        // the entity currently being dragged
+        static Entity _dragTarget;
+
         /// <summary>Scale the entire UI and all the entities in it. This is useful for smaller device screens.</summary>
         static public float GlobalScale = 1.0f;
 
@@ -71,7 +74,7 @@ namespace GeonBit.UI
 
         /// <summary>Screen width.</summary>
         static public int ScreenWidth = 0;
-        
+
         /// <summary>Screen height.</summary>
         static public int ScreenHeight = 0;
 
@@ -210,7 +213,7 @@ namespace GeonBit.UI
             spriteBatch.Draw(_cursorTexture,
                 new Rectangle(
                     (int)(cursorPos.X + _cursorOffset.X * cursorSize), (int)(cursorPos.Y + _cursorOffset.Y * cursorSize),
-                    (int)(_cursorTexture.Width * cursorSize), (int)(_cursorTexture.Height * cursorSize)), 
+                    (int)(_cursorTexture.Width * cursorSize), (int)(_cursorTexture.Height * cursorSize)),
                 Color.White);
 
             // end drawing
@@ -244,11 +247,15 @@ namespace GeonBit.UI
             // update input manager
             _input.Update(gameTime);
 
+            // unset the drag target if the mouse was released
+            if (_dragTarget != null && !_input.MouseButtonDown(MouseButton.Left)) {
+              _dragTarget = null;
+            }
+
             // update root panel
-            Entity dragTarget = null;
             Entity target = null;
             bool wasEventHandled = false;
-            _root.Update(_input, ref target, ref dragTarget, ref wasEventHandled);
+            _root.Update(_input, ref target, ref _dragTarget, ref wasEventHandled);
 
             // set active entity
             if (_input.MouseButtonDown(MouseButton.Left))
@@ -269,7 +276,7 @@ namespace GeonBit.UI
             // update screen size
             ScreenWidth = spriteBatch.GraphicsDevice.Viewport.Width;
             ScreenHeight = spriteBatch.GraphicsDevice.Viewport.Height;
-            
+
             // draw root panel
             _root.Draw(spriteBatch);
 


### PR DESCRIPTION
This fixes https://github.com/RonenNess/GeonBit.UI/issues/11 by keeping a record of the dragTarget from last frame and only changing it/unsetting it if the mouse is released.

It means that you can move the mouse as fast as you like without it dropping the dragTarget.

It doesn't change much and doesn't seem like it should affect anything other than the dragging. I've tested it out with the UI I'm working on at the moment and a blank project and everything behaves the way it usually does, so hopefully it should be fine!