### PR TITLE
SetPosition/SetOffset should set _dragOffset when entity is being dragged

### DIFF
--- a/GeonBit.UI/GeonBit.UI/Entities/Entity.cs
+++ b/GeonBit.UI/GeonBit.UI/Entities/Entity.cs
@@ -666,7 +666,7 @@ namespace GeonBit.UI.Entities
         public void SetPosition(Anchor anchor, Vector2 offset)
         {
             _anchor = anchor;
-            _offset = offset;
+            SetOffset(offset);
         }
 
         /// <summary>
@@ -684,7 +684,11 @@ namespace GeonBit.UI.Entities
         /// <param name="offset">New offset to set.</param>
         public void SetOffset(Vector2 offset)
         {
-            _offset = offset;
+            if (_isBeingDragged) {
+                _dragOffset = offset;
+            } else {
+                _offset = offset;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This was something I came across when I was trying to get a dragged entity to clamp to a grid, every time I set the position, it was being ignored in `Update`/`DrawEntity`. It turns out that `SetPosition` and `SetOffset` don't affect `Entity._dragOffset`, and so they don't actually do anything at all when the entity is being dragged.

Hopefully this PR fixes that!