### PR TITLE
Fix Entity.MouseDown being called multiple times per mousedown

### DIFF
--- a/GeonBit.UI/GeonBit.UI/Entities/Entity.cs
+++ b/GeonBit.UI/GeonBit.UI/Entities/Entity.cs
@@ -1553,7 +1553,7 @@ namespace GeonBit.UI.Entities
                 if (prevState != _entityState)
                 {
                     // mouse down
-                    if (input.MouseButtonDown())
+                    if (input.MouseButtonPressed())
                     {
                         DoOnMouseDown(input);
                     }


### PR DESCRIPTION
Looks like the `Entity.OnMouseDown` event is being fired on `input.MouseButtonDown` instead of `input.MouseButtonPressed`.

Going by the naming of `OnMouseDown`, it makes sense, but the description of the event says that it's "called once when button is pressed" so it sounds like it should be being done on press.

Maybe there should be a separate `Entity.OnMousePressed` event?

This fixes #16.