### PR TITLE
Add optional Caption to Progress Bar

### DIFF
--- a/GeonBit.UI/GeonBit.UI/Entities/ProgressBar.cs
+++ b/GeonBit.UI/GeonBit.UI/Entities/ProgressBar.cs
@@ -22,7 +22,7 @@ using Microsoft.Xna.Framework.Graphics;
 namespace GeonBit.UI.Entities
 {
     /// <summary>
-    /// A sub-class of te slider entity, with graphics more fitting for a progress bar or things like hp bar etc.
+    /// A sub-class of the slider entity, with graphics more fitting for a progress bar or things like hp bar etc.
     /// Behaves the same as a slider, if you want it to be for display only (and not changeable by user), simple set Locked = true.
     /// </summary>
     public class ProgressBar : Slider
@@ -38,6 +38,9 @@ namespace GeonBit.UI.Entities
 
         /// <summary>The fill part of the progress bar.</summary>
         public Image ProgressFill;
+
+        /// <summary>An optional caption to display over the center of the progress bar.</summary>
+        public Label Caption;
 
         /// <summary>
         /// Create progress bar with size.
@@ -58,6 +61,10 @@ namespace GeonBit.UI.Entities
             ProgressFill = new Image(Resources.ProgressBarFillTexture, Vector2.Zero, ImageDrawMode.Stretch, Anchor.CenterLeft);
             ProgressFill.UpdateStyle(DefaultFillStyle);
             AddChild(ProgressFill, true);
+
+            // the caption is just a label centered on the progress bar itself
+            Caption = new Label(string.Empty, Anchor.Center);
+            AddChild(Caption);
         }
 
         /// <summary>

--- a/GeonBit.UI/GeonBitUI_Examples.cs
+++ b/GeonBit.UI/GeonBitUI_Examples.cs
@@ -794,9 +794,10 @@ Maybe something interesting in tab3?"));
                 panel.AddChild(btn);
 
                 // change progressbar color
-                panel.AddChild(new Paragraph("Different PrograssBar colors:"));
+                panel.AddChild(new Paragraph("Different ProgressBar colors:"));
                 ProgressBar pb = new ProgressBar();
                 pb.ProgressFill.FillColor = Color.Red;
+                pb.Caption.Text = "Optional caption...";
                 panel.AddChild(pb);
 
                 // paragraph style with mouse


### PR DESCRIPTION
There we go! Okay, this is me dipping my toes into open-source development and learning pull requests and all that, while also contributing a small but useful enhancement to the library.

Pretty simple, added the optional ability to set caption text centered on a progress bar and then fixed a couple simple little typos, one in the example demo and one in the comments behind the progress bar.