### PR TITLE
TypeWriterParagraph initial

### DIFF
--- a/GeonBit.UI/GeonBit.UI.csproj
+++ b/GeonBit.UI/GeonBit.UI.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Source\Entities\StyleSheet.cs" />
     <Compile Include="Source\Entities\TextInput.cs" />
     <Compile Include="Source\Entities\TextInputValidators.cs" />
+    <Compile Include="Source\Entities\TypeWriterParagraph.cs" />
     <Compile Include="Source\Entities\VerticalScrollbar.cs" />
     <Compile Include="Source\Exceptions.cs" />
     <Compile Include="Source\Input\DefaultInputProvider.cs" />

--- a/GeonBit.UI/Source/Entities/MulticolorParagraph.cs
+++ b/GeonBit.UI/Source/Entities/MulticolorParagraph.cs
@@ -265,36 +265,7 @@ namespace GeonBit.UI.Entities
                 UpdateDestinationRects();
             }
 
-            // get outline width
-            int outlineWidth = OutlineWidth;
-
-            // if we got outline draw it
-            if (outlineWidth > 0)
-            {
-                // get outline color
-                Color outlineColor = UserInterface.Active.DrawUtils.FixColorOpacity(OutlineColor);
-
-                // for not-too-thick outline we render just two corners
-                if (outlineWidth <= MaxOutlineWidthToOptimize)
-                {
-                    spriteBatch.DrawString(_currFont, _processedText, _position + Vector2.One * outlineWidth, outlineColor,
-                        0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-                    spriteBatch.DrawString(_currFont, _processedText, _position - Vector2.One * outlineWidth, outlineColor,
-                        0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-                }
-                // for really thick outline we need to cover the other corners as well
-                else
-                {
-                    spriteBatch.DrawString(_currFont, _processedText, _position + Vector2.UnitX * outlineWidth, outlineColor,
-                        0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-                    spriteBatch.DrawString(_currFont, _processedText, _position - Vector2.UnitX * outlineWidth, outlineColor,
-                        0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-                    spriteBatch.DrawString(_currFont, _processedText, _position + Vector2.UnitY * outlineWidth, outlineColor,
-                        0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-                    spriteBatch.DrawString(_currFont, _processedText, _position - Vector2.UnitY * outlineWidth, outlineColor,
-                        0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-                }
-            }
+            DrawOutline(spriteBatch, _processedText, _position);
 
             // if there are color changing instructions in paragraph, draw with color changes
             if (_colorInstructions.Count > 0)

--- a/GeonBit.UI/Source/Entities/MulticolorParagraph.cs
+++ b/GeonBit.UI/Source/Entities/MulticolorParagraph.cs
@@ -140,7 +140,7 @@ namespace GeonBit.UI.Entities
             set
             {
                 _enableColorInstructions = value;
-                _needUpdateColors = true;
+                NeedUpdateColors = true;
             }
         }
 
@@ -154,16 +154,20 @@ namespace GeonBit.UI.Entities
                 {
                     _text = value;
                     MarkAsDirty();
-                    if (EnableColorInstructions) _needUpdateColors = true;
+                    if (EnableColorInstructions) NeedUpdateColors = true;
                 }
             }
         }
-
-        // do we need to update color-related stuff?
-        private bool _needUpdateColors = true;
-
-        // color-changing instructions in current paragraph. key is char index, value is color change command.
-        Dictionary<int, ColorInstruction> _colorInstructions = new Dictionary<int, ColorInstruction>();
+        
+        /// <summary>
+        /// Do we need to update color-related stuff?
+        /// </summary>
+        protected bool NeedUpdateColors = true;
+        
+        /// <summary>
+        /// Color-changing instructions in current paragraph. Key is char index, value is color change command.
+        /// </summary>
+        protected Dictionary<int, ColorInstruction> ColorInstructions = new Dictionary<int, ColorInstruction>();
 
         /// <summary>
         /// Create the paragraph.
@@ -205,7 +209,7 @@ namespace GeonBit.UI.Entities
         internal protected override void InitAfterDeserialize()
         {
             base.InitAfterDeserialize();
-            _needUpdateColors = true;
+            NeedUpdateColors = true;
         }
 
         // regex to find color instructions
@@ -214,10 +218,10 @@ namespace GeonBit.UI.Entities
         /// <summary>
         /// Parse special color-changing instructions inside the text.
         /// </summary>
-        private void ParseColorInstructions()
+        protected void ParseColorInstructions()
         {
             // clear previous color instructions
-            _colorInstructions.Clear();
+            ColorInstructions.Clear();
 
             // if color instructions are disabled, stop here
             if (!EnableColorInstructions) { return; }
@@ -231,7 +235,7 @@ namespace GeonBit.UI.Entities
                 foreach (System.Text.RegularExpressions.Match oMatch in oMatches)
                 {
                     string sColor = oMatch.Value.Substring(2, oMatch.Value.Length - 4);
-                    _colorInstructions.Add(oMatch.Index - iLastLength, new ColorInstruction(sColor));
+                    ColorInstructions.Add(oMatch.Index - iLastLength, new ColorInstruction(sColor));
                     iLastLength += oMatch.Value.Length;
                 }
 
@@ -240,7 +244,7 @@ namespace GeonBit.UI.Entities
             }
 
             // no longer need to update colors
-            _needUpdateColors = false;
+            NeedUpdateColors = false;
         }
 
         /// <summary>
@@ -259,7 +263,7 @@ namespace GeonBit.UI.Entities
         override protected void DrawEntity(SpriteBatch spriteBatch, DrawPhase phase)
         {
             // update processed text if needed
-            if (_needUpdateColors)
+            if (NeedUpdateColors)
             {
                 ParseColorInstructions();
                 UpdateDestinationRects();
@@ -268,7 +272,7 @@ namespace GeonBit.UI.Entities
             DrawOutline(spriteBatch, _processedText, _position);
 
             // if there are color changing instructions in paragraph, draw with color changes
-            if (_colorInstructions.Count > 0)
+            if (ColorInstructions.Count > 0)
             {
                 int iTextIndex = 0;
                 Color oColor = FillColor;
@@ -277,7 +281,7 @@ namespace GeonBit.UI.Entities
                 foreach (char cCharacter in _processedText)
                 {
                     ColorInstruction colorInstruction;
-                    if (_colorInstructions.TryGetValue(iTextIndex, out colorInstruction))
+                    if (ColorInstructions.TryGetValue(iTextIndex, out colorInstruction))
                     {
                         if (colorInstruction.UseFillColor)
                         {
@@ -306,10 +310,7 @@ namespace GeonBit.UI.Entities
                 }
             }
             // if there are no color-changing instructions, just draw the paragraph as-is
-            else
-            {
-                base.DrawEntity(spriteBatch, phase);
-            }
+            else base.DrawEntity(spriteBatch, phase);
         }
     }
 }

--- a/GeonBit.UI/Source/Entities/Paragraph.cs
+++ b/GeonBit.UI/Source/Entities/Paragraph.cs
@@ -557,6 +557,27 @@ namespace GeonBit.UI.Entities
                 spriteBatch.Draw(Resources.WhiteTexture, rect, backColor);
             }
 
+            DrawOutline(spriteBatch, _processedText, _position);
+
+            // get fill color
+            Color fillCol = UserInterface.Active.DrawUtils.FixColorOpacity(FillColor);
+
+            // draw text itself
+            spriteBatch.DrawString(_currFont, _processedText, _position, fillCol,
+                0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
+
+            // call base draw function
+            base.DrawEntity(spriteBatch, phase);
+        }
+
+        /// <summary>
+        /// Draw an outline around the paragraph
+        /// </summary>
+        /// <param name="spriteBatch">Sprite batch to draw on.</param>
+        /// <param name="text">The text to get the outline from.</param>
+        /// <param name="position">The position of the outline.</param>
+        protected void DrawOutline(SpriteBatch spriteBatch, string text, Vector2 position)
+        {
             // get outline width
             int outlineWidth = OutlineWidth;
 
@@ -569,34 +590,24 @@ namespace GeonBit.UI.Entities
                 // for not-too-thick outline we render just two corners
                 if (outlineWidth <= MaxOutlineWidthToOptimize)
                 {
-                    spriteBatch.DrawString(_currFont, _processedText, _position + Vector2.One * outlineWidth, outlineColor,
+                    spriteBatch.DrawString(_currFont, text, position + Vector2.One * outlineWidth, outlineColor,
                         0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-                    spriteBatch.DrawString(_currFont, _processedText, _position - Vector2.One * outlineWidth, outlineColor,
+                    spriteBatch.DrawString(_currFont, text, position - Vector2.One * outlineWidth, outlineColor,
                         0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
                 }
                 // for really thick outline we need to cover the other corners as well
                 else
                 {
-                    spriteBatch.DrawString(_currFont, _processedText, _position + Vector2.UnitX * outlineWidth, outlineColor,
+                    spriteBatch.DrawString(_currFont, text, position + Vector2.UnitX * outlineWidth, outlineColor,
                         0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-                    spriteBatch.DrawString(_currFont, _processedText, _position - Vector2.UnitX * outlineWidth, outlineColor,
+                    spriteBatch.DrawString(_currFont, text, position - Vector2.UnitX * outlineWidth, outlineColor,
                         0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-                    spriteBatch.DrawString(_currFont, _processedText, _position + Vector2.UnitY * outlineWidth, outlineColor,
+                    spriteBatch.DrawString(_currFont, text, position + Vector2.UnitY * outlineWidth, outlineColor,
                         0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-                    spriteBatch.DrawString(_currFont, _processedText, _position - Vector2.UnitY * outlineWidth, outlineColor,
+                    spriteBatch.DrawString(_currFont, text, position - Vector2.UnitY * outlineWidth, outlineColor,
                         0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
                 }
             }
-
-            // get fill color
-            Color fillCol = UserInterface.Active.DrawUtils.FixColorOpacity(FillColor);
-
-            // draw text itself
-            spriteBatch.DrawString(_currFont, _processedText, _position, fillCol,
-                0, _fontOrigin, _actualScale, SpriteEffects.None, 0.5f);
-
-            // call base draw function
-            base.DrawEntity(spriteBatch, phase);
         }
     }
 }

--- a/GeonBit.UI/Source/Entities/TypeWriterParagraph.cs
+++ b/GeonBit.UI/Source/Entities/TypeWriterParagraph.cs
@@ -1,0 +1,231 @@
+﻿using GeonBit.UI.Entities;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+
+namespace GeonBit.UI.Source.Entities
+{
+    /// <summary>
+    /// TypeWriter Paragraph is a paragraph that supports the type writer effect and in-text color tags that changes the fill color of the text.
+    /// </summary>
+    [System.Serializable]
+    public class TypeWriterParagraph : MulticolorParagraph
+    {
+        /// <summary>
+        /// Static ctor.
+        /// </summary>
+        static TypeWriterParagraph()
+        {
+            Entity.MakeSerializable(typeof(TypeWriterParagraph));
+        }
+        
+        /// <summary>
+        /// Enables or disables the type writer effect.
+        /// </summary>
+        public bool EnableTypeWriterEffect
+        {
+            get { return _enableTypeWriterEffect; }
+            set { _enableTypeWriterEffect = value; }
+        }
+        private bool _enableTypeWriterEffect = true;
+
+        /// <summary>
+        /// The structure of a type writer CharProperty
+        /// </summary>
+        struct CharProperty
+        {
+            /// <summary>
+            /// Actual char.
+            /// </summary>
+            public char Char;
+            /// <summary>
+            /// Color of the char.
+            /// </summary>
+            public Color Color;
+            /// <summary>
+            /// Size of the char.
+            /// </summary>
+            public Vector2 Size;
+            /// <summary>
+            /// Position of the char.
+            /// </summary>
+            public Vector2 Position;
+        }
+
+        // this list contains all the char properties generated out of the _processedText string.
+        private List<CharProperty> _charPropertyList = new List<CharProperty>();
+
+        // this timespan defines the time in milliseconds which should pass by before a new CharProperty gets added to the _CharPropertyList.
+        private TimeSpan _timeBetweenCharacters = TimeSpan.FromMilliseconds(1);
+        // this timespan gets raised by 1ms each frame and will be checked if it's greater-equal to the _timeBetweenCharacters timespan.
+        private TimeSpan _currentTime = TimeSpan.Zero;
+
+        // this index gets raised every frame and checks against the length of the _processedText string.
+        private int _iTextIndex;
+
+        // caches the last ColorInstructions color to fill the gap between different ColorInstruction colors.
+        private Color? _lastColor;
+
+        // the current maximum char width (x) reflects its position by adding its width to the character size.
+        private float _wholeCharSizeX;
+
+        // the current maximum char height (y) reflects its position by adding its height to the character size.
+        private float _wholeCharSizeY;
+
+        /// <summary>
+        /// Create the paragraph.
+        /// </summary>
+        /// <param name="text">Paragraph text (accept new line characters).</param>
+        /// <param name="anchor">Position anchor.</param>
+        /// <param name="size">Paragraph size (note: not font size, but the region that will contain the paragraph).</param>
+        /// <param name="offset">Offset from anchor position.</param>
+        /// <param name="scale">Optional font size.</param>
+        /// <param name="timeBetweenChars">After this time a new char of the text value will be drawn. Default: 1ms</param>
+        public TypeWriterParagraph(string text, Anchor anchor = Anchor.Auto, Vector2? size = null, Vector2? offset = null, float? scale = null, TimeSpan? timeBetweenChars = null) :
+            base(text, anchor, size, offset, scale)
+        {
+            _timeBetweenCharacters = timeBetweenChars ?? _timeBetweenCharacters;
+        }
+
+        /// <summary>
+        /// Create the paragraph with optional fill color and font size.
+        /// </summary>
+        /// <param name="text">Paragraph text (accept new line characters).</param>
+        /// <param name="anchor">Position anchor.</param>
+        /// <param name="color">Text fill color.</param>
+        /// <param name="scale">Optional font size.</param>
+        /// <param name="size">Paragraph size (note: not font size, but the region that will contain the paragraph).</param>
+        /// <param name="offset">Offset from anchor position.</param>
+        /// <param name="timeBetweenChars">After this time a new char of the text value will be drawn. Default: 1ms</param>
+        public TypeWriterParagraph(string text, Anchor anchor, Color color, float? scale = null, Vector2? size = null, Vector2? offset = null, TimeSpan? timeBetweenChars = null) :
+            base(text, anchor, color, scale, size, offset)
+        {
+            _timeBetweenCharacters = timeBetweenChars ?? _timeBetweenCharacters;
+        }
+
+        /// <summary>
+        /// Create default TypeWriterParagraph with empty text.
+        /// </summary>
+        public TypeWriterParagraph() : this(string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Draw entity outline. Note: in paragraph its a special case and we implement it inside the DrawEntity function.
+        /// </summary>
+        /// <param name="spriteBatch">Sprite batch to draw on.</param>
+        override protected void DrawEntityOutline(SpriteBatch spriteBatch)
+        {
+        }
+
+        /// <summary>
+        /// Draw the entity.
+        /// </summary>
+        /// <param name="spriteBatch">Sprite batch to draw on.</param>
+        /// <param name="phase">The phase we are currently drawing.</param>
+        override protected void DrawEntity(SpriteBatch spriteBatch, DrawPhase phase)
+        {
+            if (_enableTypeWriterEffect)
+            {
+                // update processed text if needed
+                if (NeedUpdateColors)
+                {
+                    ParseColorInstructions();
+                    UpdateDestinationRects();
+                }
+
+                CreateCharArray();
+                DrawCharProperty(spriteBatch);
+            }
+            else base.DrawEntity(spriteBatch, phase);
+        }
+
+        /// <summary>
+        /// Draw a char together with its properties to the spritebatch.
+        /// </summary>
+        /// <param name="spriteBatch">Sprite batch to draw on.</param>
+        private void DrawCharProperty(SpriteBatch spriteBatch)
+        {
+            foreach (CharProperty charProperty in _charPropertyList)
+            {
+                DrawOutline(spriteBatch, charProperty.Char.ToString(), charProperty.Position);
+
+                // fix color opacity and draw the corresponding main string
+                spriteBatch.DrawString(
+                    _currFont,
+                    charProperty.Char.ToString(),
+                    charProperty.Position,
+                    UserInterface.Active.DrawUtils.FixColorOpacity(charProperty.Color),
+                    0,
+                    _fontOrigin,
+                    _actualScale,
+                    SpriteEffects.None,
+                    0.5f);
+            }
+        }
+
+        // iterates through the _processedText string and creates CharProperty objects based on its chars
+        private void CreateCharArray()
+        {
+            if (_enableTypeWriterEffect)
+            {
+                if (_currentTime >= _timeBetweenCharacters)
+                {
+                    if (_iTextIndex < _processedText.Length)
+                    {
+                        AddChar(_iTextIndex);
+
+                        _currentTime = TimeSpan.Zero;
+                        _iTextIndex++;
+                    }
+                }
+                else _currentTime += TimeSpan.FromMilliseconds(1);
+            }
+            else
+            {
+                for (int i = 0; i < _processedText.Length; i++) AddChar(i);
+            }
+        }
+
+        // adds a single char together with its properties to the _CharPropertyList.
+        private void AddChar(int index)
+        {
+            if (_charPropertyList.Count < _processedText.Length)
+            {
+                CharProperty charProperty = new CharProperty();
+                charProperty.Color = FillColor;
+                charProperty.Char = _processedText[index];
+                charProperty.Size = GetCharacterActualSize();
+                charProperty.Position = _position;
+
+                if (ColorInstructions.Count > 0)
+                {
+                    ColorInstruction colorInstruction;
+                    if (ColorInstructions != null && ColorInstructions.TryGetValue(index, out colorInstruction))
+                    {
+                        if (colorInstruction.UseFillColor) charProperty.Color = FillColor;
+                        else charProperty.Color = colorInstruction.Color;
+
+                        _lastColor = charProperty.Color;
+                    }
+                    else charProperty.Color = _lastColor ?? FillColor;
+                }
+
+                if (charProperty.Char != '\n')
+                {
+                    _wholeCharSizeX += charProperty.Size.X;
+                }
+                else
+                {
+                    _wholeCharSizeX = 0;
+                    _wholeCharSizeY += charProperty.Size.Y;
+                }
+                charProperty.Position.X += _wholeCharSizeX;
+                charProperty.Position.Y += _wholeCharSizeY;
+
+                _charPropertyList.Add(charProperty);
+            }
+        }
+    }
+}

--- a/GeonBit.UI/Source/Entities/TypeWriterParagraph.cs
+++ b/GeonBit.UI/Source/Entities/TypeWriterParagraph.cs
@@ -112,6 +112,29 @@ namespace GeonBit.UI.Source.Entities
         }
 
         /// <summary>
+        /// Update dest rect and internal dest rect.
+        /// This is called internally whenever a change is made to the entity or its parent.
+        /// </summary>
+        override internal protected void UpdateDestinationRects()
+        {
+            // call base function
+            base.UpdateDestinationRects();
+
+            _wholeCharSizeX = 0;
+            _wholeCharSizeY = 0;
+
+            for (int i = 0; i < _charPropertyList.Count; i++)
+            {
+                CharProperty newCharProperty = _charPropertyList[i];
+                newCharProperty.Size = GetCharacterActualSize();
+                newCharProperty.Position = _position;
+
+                CalculateCharSizePosition(ref newCharProperty);
+                _charPropertyList[i] = newCharProperty;
+            }
+        }
+
+        /// <summary>
         /// Draw entity outline. Note: in paragraph its a special case and we implement it inside the DrawEntity function.
         /// </summary>
         /// <param name="spriteBatch">Sprite batch to draw on.</param>
@@ -212,20 +235,25 @@ namespace GeonBit.UI.Source.Entities
                     else charProperty.Color = _lastColor ?? FillColor;
                 }
 
-                if (charProperty.Char != '\n')
-                {
-                    _wholeCharSizeX += charProperty.Size.X;
-                }
-                else
-                {
-                    _wholeCharSizeX = 0;
-                    _wholeCharSizeY += charProperty.Size.Y;
-                }
-                charProperty.Position.X += _wholeCharSizeX;
-                charProperty.Position.Y += _wholeCharSizeY;
-
+                CalculateCharSizePosition(ref charProperty);
                 _charPropertyList.Add(charProperty);
             }
+        }
+
+        // calculate the size and the position of a char.
+        private void CalculateCharSizePosition(ref CharProperty charProperty)
+        {
+            if (charProperty.Char != '\n')
+            {
+                _wholeCharSizeX += charProperty.Size.X;
+            }
+            else
+            {
+                _wholeCharSizeX = 0;
+                _wholeCharSizeY += charProperty.Size.Y;
+            }
+            charProperty.Position.X += _wholeCharSizeX;
+            charProperty.Position.Y += _wholeCharSizeY;
         }
     }
 }


### PR DESCRIPTION
The **TypeWriterParagraph** adds the **type writer effect** to text. It inherits from MultiColorParagraph to support multiple colors.

As I inherited from the MultiColorParagraph I noticed that the drawing of the outline is the same code block as used by the base Paragraph class (compare [Paragraph](https://github.com/RonenNess/GeonBit.UI/blob/master/GeonBit.UI/Source/Entities/Paragraph.cs#L560) vs [MultiColorParagraph](https://github.com/RonenNess/GeonBit.UI/blob/master/GeonBit.UI/Source/Entities/MulticolorParagraph.cs#L268))

So I decided to wrap this up in a [protected void](https://github.com/RonenNess/GeonBit.UI/blob/07565949377802083bf6f1fa8f50911534d4cfcb/GeonBit.UI/Source/Entities/Paragraph.cs#L579) to make it available in derived classes like the MultiColorParagraph and the new TypeWriterParagraph.

Commit 9e6c93e opens up some important members of the MultiColorParagraph so that classes that inherit from it (like the new TypeWriterParagraph) can benefit from.

It's possible to change the speed of the type writer effect by overloading the ctor and modifying the **timeBetweenChars** value.

---

This is just the basic implementation with a basic effect. In the future this TypeWriterParagraph could be modified to work the same way as the MultiColorParagraph by setting speed values directly in the text (like a ColorInstruction).