### PR TITLE
Slider change value on scroll only when mouse hover

### DIFF
--- a/GeonBit.UI/Source/Entities/Slider.cs
+++ b/GeonBit.UI/Source/Entities/Slider.cs
@@ -303,7 +303,10 @@ namespace GeonBit.UI.Entities
         /// </summary>
         override protected void DoOnMouseWheelScroll()
         {
-            Value = _value + MouseInput.MouseWheelChange * GetStepSize();
+            if (_isMouseOver)
+            {
+                Value = _value + MouseInput.MouseWheelChange * GetStepSize();
+            }
         }
     }
 }


### PR DESCRIPTION
This prevent from scrolling with the mouse and changing slider when the mouse is not hovering the slider.
For example: If we have multiple slider in a tab if we changed value of a slider by clicking with the mouse and the hover another slider an scroll, the two would change values.

Here is an example with some before/after GIFs:
![output_before](https://user-images.githubusercontent.com/27897009/83514873-b7174900-a4d4-11ea-9832-a55cc7a90d81.gif)
![output_after](https://user-images.githubusercontent.com/27897009/83515517-cc40a780-a4d5-11ea-950d-5a274586f84b.gif)