### PR TITLE
LineSpace-Entity crashes UI & APP when Scaled <= 100%

### DIFF
--- a/GeonBit.UI/Source/Entities/LineSpace.cs
+++ b/GeonBit.UI/Source/Entities/LineSpace.cs
@@ -44,7 +44,7 @@ namespace GeonBit.UI.Entities
             ClickThrough = true;
 
             // set size based on space count
-            Size = new Vector2(0, 1);
+            Size = new Vector2(0, 0.01f);
 
             // default padding and spacing zero
             SpaceBefore = Padding = Vector2.Zero;


### PR DESCRIPTION
I just encountered this bug which crashes the UI and the application.

Steps to reproduce:

1. Download the unmodified master branch
2. Build & Run the official example
3. Click the "Next ->"-Button till you reach the "Buttons"-Example (which includes LineSpace-Entities)
4. Now Scale-Down to 95%
5. UI & APP Crashes

After applying this fix it works as expected (inclusive the "spacesCount"-Overload).

---

**Note:** I'm not sure if this is the right way to fix this bug, because I just jumped-in to the newest version of GeonBit.UI and immediately got this bug and applied this simple fix.

What I also experienced is that when you scale the UI to 105% first and then back to 100% it will also crash the UI and the APP in the above mentioned example.

It seems to be like an infinite loop and the space before and after a LineSpacer seems to get infinitley extended. So the root cause might be somwhere else.

However, because I experienced no draw-backs so far I pushed this PR.

Thanks for checking!