### PR TITLE
FontName properties changed in the built-in themes to avoid the manual font installation step

### DIFF
--- a/GeonBit.UI/Content/GeonBit.UI/Themes/editor/fonts/Bold.spritefont
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/editor/fonts/Bold.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>Bitstream Vera Sans Mono Bold</FontName>
+    <FontName>../../../../Fonts/Bitstream Vera Sans Mono Bold.ttf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/editor/fonts/Italic.spritefont
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/editor/fonts/Italic.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>Bitstream Vera Sans Mono Oblique</FontName>
+    <FontName>../../../../Fonts/Bitstream Vera Sans Mono Oblique.ttf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/editor/fonts/Regular.spritefont
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/editor/fonts/Regular.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>Bitstream Vera Sans Mono Roman</FontName>
+    <FontName>../../../../Fonts/Bitstream Vera Sans Mono Roman.ttf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/hd/fonts/Bold.spritefont
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/hd/fonts/Bold.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>Bitstream Vera Sans Mono Bold</FontName>
+    <FontName>../../../../Fonts/Bitstream Vera Sans Mono Bold.ttf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/hd/fonts/Italic.spritefont
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/hd/fonts/Italic.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>Bitstream Vera Sans Mono Oblique</FontName>
+    <FontName>../../../../Fonts/Bitstream Vera Sans Mono Oblique.ttf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/hd/fonts/Regular.spritefont
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/hd/fonts/Regular.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>Bitstream Vera Sans Mono Roman</FontName>
+    <FontName>../../../../Fonts/Bitstream Vera Sans Mono Roman.ttf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/fonts/Bold.spritefont
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/fonts/Bold.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>AnonymousPro-Bold</FontName>
+    <FontName>../../../../Fonts/AnonymousPro-Bold.ttf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/fonts/Italic.spritefont
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/fonts/Italic.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>AnonymousPro-Italic</FontName>
+    <FontName>../../../../Fonts/AnonymousPro-Italic.ttf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/fonts/Regular.spritefont
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/fonts/Regular.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>AnonymousPro-Regular</FontName>
+    <FontName>../../../../Fonts/AnonymousPro-Regular.ttf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change


### PR DESCRIPTION
I have found that if we changed FontName property of spritefonts to point to the corresponding font files then we wouldn't need to have these fonts installed. An ugly manual font installation step would not be necessary any more.