### PR TITLE
Fix incorrect RGB values in xml

### DIFF
--- a/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/CheckBoxParagraph-MouseDown.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/CheckBoxParagraph-MouseDown.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>255</B>
+    <B>0</B>
     <G>255</G>
-    <R>0</R>
+    <R>255</R>
     <A>255</A>
     <PackedValue>4294967040</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/CheckBoxParagraph-MouseHover.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/CheckBoxParagraph-MouseHover.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>255</B>
+    <B>0</B>
     <G>255</G>
-    <R>0</R>
+    <R>255</R>
     <A>255</A>
     <PackedValue>4294967040</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/Header-Default.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/Header-Default.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale>1.2</Scale>
   <FillColor>
-    <B>255</B>
+    <B>0</B>
     <G>255</G>
-    <R>0</R>
+    <R>255</R>
     <A>255</A>
     <PackedValue>4294967040</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/ProgressBarFill-Default.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/ProgressBarFill-Default.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>255</B>
+    <B>0</B>
     <G>255</G>
-    <R>0</R>
+    <R>255</R>
     <A>255</A>
     <PackedValue>4294967040</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/SelectListParagraph-MouseDown.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/SelectListParagraph-MouseDown.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>255</B>
+    <B>0</B>
     <G>255</G>
-    <R>0</R>
+    <R>255</R>
     <A>255</A>
     <PackedValue>4294967040</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/SelectListParagraph-MouseHover.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/editor/styles/SelectListParagraph-MouseHover.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>255</B>
+    <B>0</B>
     <G>255</G>
-    <R>0</R>
+    <R>255</R>
     <A>255</A>
     <PackedValue>4294967040</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/CheckBoxParagraph-MouseDown.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/CheckBoxParagraph-MouseDown.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>0</B>
+    <B>255</B>
     <G>255</G>
-    <R>255</R>
+    <R>0</R>
     <A>255</A>
     <PackedValue>4278255615</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/CheckBoxParagraph-MouseHover.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/CheckBoxParagraph-MouseHover.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>0</B>
+    <B>255</B>
     <G>255</G>
-    <R>255</R>
+    <R>0</R>
     <A>255</A>
     <PackedValue>4278255615</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/Header-Default.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/Header-Default.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale>1.2</Scale>
   <FillColor>
-    <B>0</B>
+    <B>255</B>
     <G>255</G>
-    <R>255</R>
+    <R>0</R>
     <A>255</A>
     <PackedValue>4278255615</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/ProgressBarFill-Default.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/ProgressBarFill-Default.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>64</B>
+    <B>132</B>
     <G>204</G>
-    <R>132</R>
+    <R>64</R>
     <A>255</A>
     <PackedValue>4282436740</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/SelectListParagraph-MouseDown.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/SelectListParagraph-MouseDown.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>0</B>
+    <B>255</B>
     <G>255</G>
-    <R>255</R>
+    <R>0</R>
     <A>255</A>
     <PackedValue>4278255615</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/SelectListParagraph-MouseHover.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/hd/styles/SelectListParagraph-MouseHover.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>0</B>
+    <B>255</B>
     <G>255</G>
-    <R>255</R>
+    <R>0</R>
     <A>255</A>
     <PackedValue>4278255615</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/CheckBoxParagraph-MouseDown.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/CheckBoxParagraph-MouseDown.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>0</B>
+    <B>255</B>
     <G>255</G>
-    <R>255</R>
+    <R>0</R>
     <A>255</A>
     <PackedValue>4278255615</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/CheckBoxParagraph-MouseHover.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/CheckBoxParagraph-MouseHover.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>0</B>
+    <B>255</B>
     <G>255</G>
-    <R>255</R>
+    <R>0</R>
     <A>255</A>
     <PackedValue>4278255615</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/Header-Default.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/Header-Default.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale>1.2</Scale>
   <FillColor>
-    <B>0</B>
+    <B>255</B>
     <G>255</G>
-    <R>255</R>
+    <R>0</R>
     <A>255</A>
     <PackedValue>4278255615</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/ProgressBarFill-Default.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/ProgressBarFill-Default.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>64</B>
+    <B>132</B>
     <G>204</G>
-    <R>132</R>
+    <R>64</R>
     <A>255</A>
     <PackedValue>4282436740</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/SelectListParagraph-MouseDown.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/SelectListParagraph-MouseDown.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>0</B>
+    <B>255</B>
     <G>255</G>
-    <R>255</R>
+    <R>0</R>
     <A>255</A>
     <PackedValue>4278255615</PackedValue>
   </FillColor>

--- a/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/SelectListParagraph-MouseHover.xml
+++ b/GeonBit.UI/Content/GeonBit.UI/Themes/lowres/styles/SelectListParagraph-MouseHover.xml
@@ -11,9 +11,9 @@
   <DefaultSize xsi:nil="true" />
   <Scale xsi:nil="true" />
   <FillColor>
-    <B>0</B>
+    <B>255</B>
     <G>255</G>
-    <R>255</R>
+    <R>0</R>
     <A>255</A>
     <PackedValue>4278255615</PackedValue>
   </FillColor>


### PR DESCRIPTION
Fix incorrect RGB values in xml (they seem to have no effect in the example program because it uses the packed value, however it is a source of confusion for anyone who is debugging or trying to figure out how the code works).