### PR TITLE
Added missing "Trap" icon to the IconType enum.

### DIFF
--- a/GeonBit.UI/Source/Entities/Icon.cs
+++ b/GeonBit.UI/Source/Entities/Icon.cs
@@ -118,6 +118,8 @@ namespace GeonBit.UI.Entities
         OrbBlue,
         /// <summary>'OrbGreen' Icon.</summary>
         OrbGreen,
+        /// <summary>'Trap' Icon.</summary>
+        Trap,
         /// <summary>'ZoomIn' Icon.</summary>
         ZoomIn,
         /// <summary>'ZoomOut' Icon.</summary>


### PR DESCRIPTION
The "Trap" icon is the only icon missing from the "IconType" enum. So I added it there :)